### PR TITLE
Tweet processing modifications

### DIFF
--- a/classify/.env.sample
+++ b/classify/.env.sample
@@ -3,3 +3,8 @@ DB_USER=
 DB_PASS=
 DB_HOST=
 DB_NAME=
+
+# Kafka
+KAFKA_TOPIC=tweets
+KAFKA_BOOTSTRAP_SERVERS=
+KAFKA_GROUP=python-consumer

--- a/classify/process_tweets.py
+++ b/classify/process_tweets.py
@@ -23,11 +23,11 @@ from pony import orm
 # Globals
 
 ## Kafka Config
-TOPICS = ['tweets-v4']
+TOPICS = getenv('KAFKA_TOPIC').split(',')
 TWEETS_INTERVAL = 100
 SLEEP_INTERVAL = 10
-BOOTSTRAP_SERVERS = 'kafka.rasbonics.com:29092'
-KAFKA_GROUP = 'python-consumer'
+BOOTSTRAP_SERVERS = getenv('KAFKA_BOOTSTRAP_SERVERS')
+KAFKA_GROUP = getenv('KAFKA_GROUP')
 
 ## Postgres Config
 DB = orm.Database()

--- a/streaming/scala/tweet_streaming.service
+++ b/streaming/scala/tweet_streaming.service
@@ -1,0 +1,40 @@
+# This file should be added at /etc/systemd/system/tweet_streaming.service
+# Twitter credentials in "Environment" section below must be set.
+
+[Unit]
+Description=Tweet Streaming Service
+After=network.target
+
+[Service]
+Type=simple
+
+# Run as root
+User=root
+
+# The path to run at
+WorkingDirectory=/root/streaming/scala
+
+# Set credentials for twitter
+Environment=INTERVAL_SECONDS=2
+Environment=TWITTER_CONSUMER_KEY=[SET CREDENTIAL HERE]
+Environment=TWITTER_CONSUMER_SECRET=[SET CREDENTIAL HERE]
+Environment=TWITTER_ACCESS_TOKEN=[SET CREDENTIAL HERE]
+Environment=TWITTER_ACCESS_TOKEN_SECRET=[SET CREDENTIAL HERE]
+
+ExecStart=/usr/local/spark/bin/spark-submit \
+          --packages org.apache.bahir:spark-streaming-twitter_2.11:2.1.1,org.apache.kafka:kafka-clients:2.1.0 \
+          --master spark://spark1:7077 \
+          target/scala-2.11/final-project_2.11-1.0.jar \
+          $INTERVAL_SECONDS \
+          /root/streaming/inputs/vocabulary3.txt \
+          $TWITTER_CONSUMER_KEY \
+          $TWITTER_CONSUMER_SECRET \
+          $TWITTER_ACCESS_TOKEN \
+          $TWITTER_ACCESS_TOKEN_SECRET
+
+ExecStop=pkill spark-submit
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR makes the `process_tweets.py` a bit less brittle by using environment variables rather than hard-coded values for the Kafka configuration.

It also adds a `tweet_streaming.service` file, which automates starting/stopping/logging of the streaming Spark service.

I'm going to go ahead and merge this, but I'm creating this PR for easy review. Thanks!